### PR TITLE
Simplified how plugin knows isLive

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -25,4 +25,5 @@
 return [
     // YouTube Channel ID
     "youtubeChannelId" => '',
+    "isLive" => false,
 ];

--- a/src/controllers/InfoController.php
+++ b/src/controllers/InfoController.php
@@ -27,7 +27,6 @@ class InfoController extends Controller
 
     protected $allowAnonymous = [
         'is-live',
-        'live-viewers',
     ];
 
     // Public Methods
@@ -42,15 +41,5 @@ class InfoController extends Controller
     public function actionIsLive(): bool
     {
         return YoutubeLiveEmbed::$plugin->embed->isLive();
-    }
-
-    /**
-     * Returns the number of people currently viewing the live stream
-     *
-     * @return int
-     */
-    public function actionLiveViewers(): int
-    {
-        return YoutubeLiveEmbed::$plugin->embed->liveViewers();
     }
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -27,6 +27,11 @@ class Settings extends Model
      */
     public $youtubeChannelId = '';
 
+    /**
+     * @var bool
+     */
+    public $isLive = false;
+
     // Public Methods
     // =========================================================================
 
@@ -38,6 +43,8 @@ class Settings extends Model
         return [
             ['youtubeChannelId', 'string'],
             ['youtubeChannelId', 'default', 'value' => ''],
+            ['isLive', 'boolean'],
+            ['isLive', 'default', 'value' => false],
         ];
     }
 }

--- a/src/services/Embed.php
+++ b/src/services/Embed.php
@@ -31,7 +31,6 @@ class Embed extends Component
 
     const YOUTUBE_STREAM_URL = 'https://www.youtube.com/embed/live_stream';
     const YOUTUBE_CHAT_URL = 'https://www.youtube.com/live_chat';
-    const YOUTUBE_LIVE_STATS_URL = 'https://www.youtube.com/live_stats';
 
     // Public Methods
     // =========================================================================
@@ -137,29 +136,12 @@ class Embed extends Component
      */
     public function isLive(): bool
     {
-        return (bool)$this->liveViewers();
-    }
-
-    /**
-     * Returns the number of people currently viewing the live stream
-     *
-     * @return int
-     */
-    public function liveViewers(): int
-    {
-        $count = 0;
         $videoId = $this->getVideoIdFromLiveStream();
         if ($videoId) {
-            $liveUrl = UrlHelper::urlWithParams(self::YOUTUBE_LIVE_STATS_URL, [
-                'v' => $this->getVideoIdFromLiveStream(),
-            ]);
-            // Fetch the livestream page
-            if ($data = @file_get_contents($liveUrl)) {
-                $count = (int)$data;
-            }
+            return true;
         }
 
-        return $count;
+        return false;
     }
 
     // Protected Methods

--- a/src/services/Embed.php
+++ b/src/services/Embed.php
@@ -136,12 +136,7 @@ class Embed extends Component
      */
     public function isLive(): bool
     {
-        $videoId = $this->getVideoIdFromLiveStream();
-        if ($videoId) {
-            return true;
-        }
-
-        return false;
+        return YoutubeLiveEmbed::getInstance()->settings->isLive;
     }
 
     // Protected Methods
@@ -157,7 +152,6 @@ class Embed extends Component
         $url =  UrlHelper::urlWithParams(self::YOUTUBE_STREAM_URL, [
             'channel' => YoutubeLiveEmbed::$youtubeChannelId,
         ]);
-
         return $url;
     }
 

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -22,3 +22,10 @@
     name: 'youtubeChannelId',
     value: settings['youtubeChannelId']})
 }}
+{{ forms.lightswitchField({
+    label: 'Is the stream live?',
+    instructions: '',
+    id: 'isLive',
+    name: 'isLive',
+    on: settings['isLive']})
+}}

--- a/src/variables/YoutubeLiveEmbedVariable.php
+++ b/src/variables/YoutubeLiveEmbedVariable.php
@@ -97,14 +97,4 @@ class YoutubeLiveEmbedVariable
     {
         return YoutubeLiveEmbed::$plugin->embed->isLive();
     }
-
-    /**
-     * Returns the number of people currently viewing the live stream
-     *
-     * @return int
-     */
-    public function liveViewers(): int
-    {
-        return YoutubeLiveEmbed::$plugin->embed->liveViewers();
-    }
 }


### PR DESCRIPTION
- removed all mentioned of liveViewers() because the stats page was removed by YouTube
- isLive is now triggered by whether the plugin can successfully get a videoId. The videoId is only available for _public_ livestreams. And will return a videoId even if the livestream is public but not yet streaming.